### PR TITLE
Fix Makefile clear_eeprom with -s eeprom

### DIFF
--- a/src/controller/Makefile
+++ b/src/controller/Makefile
@@ -107,9 +107,9 @@ backup:
 
 flash:
 	stm8flash -c stlinkv2 -p stm8s105?6 -w $(ODIR)/$(PNAME).ihx
-# This is 
+
 clear_eeprom:
-	stm8flash -c stlinkv2 -p stm8s105?6 -w data_empty.ihx
+	stm8flash -c stlinkv2 -p stm8s105?6 -s eeprom -w data_empty.ihx
 
 
 clean:


### PR DESCRIPTION
This solves https://github.com/emmebrusa/TSDZ2-Smart-EBike-1/issues/54 in linux environments